### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kishankumarhs/fnkit/security/code-scanning/1](https://github.com/kishankumarhs/fnkit/security/code-scanning/1)

To fix this problem, add a `permissions` block to the workflow. Since this workflow only checks out contents, sets up Go, builds, and tests, it only requires read-only access to the repository contents. The recommended fix is to add a `permissions` key with `contents: read` at either the root level (to apply to all jobs) or within the specific job. The best practice is adding it at the root, just below the `name` and before `on`. Modify .github/workflows/go.yml by inserting the following:

```yaml
permissions:
  contents: read
```

Place this block after the workflow `name:` (line 4), and before the `on:` trigger definition. No additional methods, imports, or dependency changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
